### PR TITLE
Feature/Ability to use RSET, configure delay responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     - image: cimg/ruby:<< parameters.ruby-version >>
 
 orbs:
-  ruby: circleci/ruby@1.7.1
+  ruby: circleci/ruby@1.8.0
 
 references:
   restore_bundle_cache: &restore_bundle_cache
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - <<: *use_compatible_gemspec
       - ruby/install-deps:
-          bundler-version: "2.3.13"
+          bundler-version: "2.3.18"
           with-cache: false
           path: './vendor/custom_bundle'
       - <<: *system_dependencies

--- a/.circleci/gemspec_latest
+++ b/.circleci/gemspec_latest
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'dry-struct', '~> 1.4'
 
-  spec.add_development_dependency 'bundler-audit', '~> 0.9.0.1'
+  spec.add_development_dependency 'bundler-audit', '~> 0.9.1'
   spec.add_development_dependency 'fasterer', '~> 0.10.0'
   spec.add_development_dependency 'ffaker', '~> 2.21'
   spec.add_development_dependency 'net-smtp', '~> 0.3.1'
@@ -40,8 +40,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'reek', '~> 6.1', '>= 6.1.1'
   spec.add_development_dependency 'rspec', '~> 3.11'
-  spec.add_development_dependency 'rubocop', '~> 1.29', '>= 1.29.1'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.13', '>= 1.13.3'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.10'
+  spec.add_development_dependency 'rubocop', '~> 1.32'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.14', '>= 1.14.3'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.12', '>= 2.12.1'
   spec.add_development_dependency 'simplecov', '~> 0.21.2'
 end

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-29
+    channel: rubocop-1-32
 
   reek:
     enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
   DisplayCopNames:    true
   DisplayStyleGuide:  true
   TargetRubyVersion:  2.5
+  NewCops: enable
+
+# Metrics ---------------------------------------------------------------------
 
 Metrics/ClassLength:
   Max: 150
@@ -22,6 +25,8 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+# Naming ----------------------------------------------------------------------
+
 Naming/VariableNumber:
   Enabled: false
 
@@ -31,8 +36,7 @@ Naming/RescuedExceptionsVariableName:
 Naming/InclusiveLanguage:
   Enabled: false
 
-Naming/BlockForwarding:
-  Enabled: true
+# Style -----------------------------------------------------------------------
 
 Style/Documentation:
   Enabled: false
@@ -49,146 +53,10 @@ Style/ParallelAssignment:
 Style/RescueStandardError:
   Enabled: false
 
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/AccessorGrouping:
-  Enabled: true
-
-Style/ArrayCoercion:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-Style/CaseLikeIf:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
-Style/ArgumentsForwarding:
-  Enabled: true
-
-Style/CollectionCompact:
-  Enabled: true
-
-Style/DocumentDynamicEvalDefinition:
-  Enabled: true
-
-Style/NegatedIfElseCondition:
-  Enabled: true
-
-Style/NilLambda:
-  Enabled: true
-
-Style/RedundantArgument:
-  Enabled: true
-
-Style/SwapValues:
-  Enabled: true
-
-Style/EndlessMethod:
-  Enabled: true
-
-Style/HashExcept:
-  Enabled: true
-
-Style/IfWithBooleanLiteralBranches:
-  Enabled: true
-
-Style/HashConversion:
-  Enabled: true
-
-Style/StringChars:
-  Enabled: true
-
-Style/InPatternThen:
-  Enabled: true
-
-Style/MultilineInPatternThen:
-  Enabled: true
-
-Style/QuotedSymbols:
-  Enabled: true
-
-Style/RedundantSelfAssignmentBranch:
-  Enabled: true
-
-Style/NumberedParameters:
-  Enabled: true
-
-Style/NumberedParametersLimit:
-  Enabled: true
-
-Style/SelectByRegexp:
-  Enabled: true
-
-Style/FileRead:
-  Enabled: true
-
-Style/FileWrite:
-  Enabled: true
-
-Style/MapToHash:
-  Enabled: true
-
-Style/OpenStructUse:
-  Enabled: true
-
-Style/NestedFileDirname:
-  Enabled: true
-
-Style/EnvHome:
-  Enabled: true
-
-Style/FetchEnvVar:
-  Enabled: true
-
-Style/ObjectThen:
-  Enabled: true
-
-Style/RedundantInitialize:
-  Enabled: true
+# Layout ----------------------------------------------------------------------
 
 Layout/LineLength:
   Max: 150
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 Layout/ClassStructure:
   Enabled: true
@@ -209,164 +77,17 @@ Layout/ClassStructure:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/SpaceBeforeBrackets:
-  Enabled: true
-
-Layout/LineEndStringConcatenationIndentation:
-  Enabled: true
-
-Lint/NonDeterministicRequireOrder:
-  Enabled: true
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/DuplicateElsifCondition:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Lint/DuplicateBranch:
-  Enabled: true
-
-Lint/DuplicateRegexpCharacterClassElement:
-  Enabled: true
-
-Lint/EmptyBlock:
-  Enabled: true
-
-Lint/EmptyClass:
-  Enabled: true
-
-Lint/NoReturnInBeginEndBlocks:
-  Enabled: true
-
-Lint/ToEnumArguments:
-  Enabled: true
-
-Lint/UnexpectedBlockArity:
-  Enabled: true
-
-Lint/AmbiguousAssignment:
-  Enabled: true
-
-Lint/DeprecatedConstants:
-  Enabled: true
-
-Lint/LambdaWithoutLiteralBlock:
-  Enabled: true
-
-Lint/RedundantDirGlobSort:
-  Enabled: true
-
-Lint/UnmodifiedReduceAccumulator:
-  Enabled: true
-
-Lint/NumberedParameterAssignment:
-  Enabled: true
-
-Lint/OrAssignmentToConstant:
-  Enabled: true
-
-Lint/SymbolConversion:
-  Enabled: true
-
-Lint/TripleQuotes:
-  Enabled: true
-
-Lint/EmptyInPattern:
-  Enabled: true
-
-Lint/AmbiguousRange:
-  Enabled: true
-
-Lint/AmbiguousOperatorPrecedence:
-  Enabled: true
-
-Lint/IncompatibleIoSelectWithFiberScheduler:
-  Enabled: true
-
-Lint/RequireRelativeSelfPath:
-  Enabled: true
-
-Lint/RefinementImportMethods:
-  Enabled: true
-
-Lint/UselessRuby2Keywords:
-  Enabled: true
-
-Gemspec/DateAssignment:
-  Enabled: true
+# Gemspec ---------------------------------------------------------------------
 
 Gemspec/RequireMFA:
   Enabled: false
 
-Security/IoMethods:
-  Enabled: true
-
-Security/CompoundHash:
-  Enabled: true
-
-Performance/AncestorsInclude:
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-
-Performance/RedundantSortBlock:
-  Enabled: true
-
-Performance/RedundantStringChars:
-  Enabled: true
-
-Performance/ReverseFirst:
-  Enabled: true
-
-Performance/SortReverse:
-  Enabled: true
-
-Performance/Squeeze:
-  Enabled: true
-
-Performance/StringInclude:
-  Enabled: true
-
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
-
-Performance/CollectionLiteralInLoop:
-  Enabled: true
-
-Performance/ConstantRegexp:
-  Enabled: true
+# Performance -----------------------------------------------------------------
 
 Performance/MethodObjectAsBlock:
   Enabled: false
 
-Performance/Sum:
-  Enabled: true
-
-Performance/RedundantEqualityComparisonBlock:
-  Enabled: true
-
-Performance/RedundantSplitRegexpArgument:
-  Enabled: true
-
-Performance/MapCompact:
-  Enabled: true
-
-Performance/ConcurrentMonotonicTime:
-  Enabled: true
-
-Performance/StringIdentifierArgument:
-  Enabled: true
+# RSpec -----------------------------------------------------------------------
 
 RSpec/ExampleLength:
   Enabled: false
@@ -397,27 +118,6 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/StubbedMock:
   Enabled: false
-
-RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-
-RSpec/Rails/AvoidSetupHook:
-  Enabled: true
-
-RSpec/ExcessiveDocstringSpacing:
-  Enabled: true
-
-RSpec/SubjectDeclaration:
-  Enabled: true
-
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: true
-
-RSpec/BeEq:
-  Enabled: true
-
-RSpec/BeNil:
-  Enabled: true
 
 RSpec/VerifiedDoubleReference:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2022-07-27
+
+### Added
+
+- Ability to use `RSET` SMTP command
+- Ability to configure multiple message receiving flow during one session
+- Ability to configure SMTP command delay responses
+
+### Updated
+
+- Updated gemspecs
+- Updated tests
+- Updated rubocop/codeclimate/circleci configs
+- Updated gem development dependencies
+- Updated gem documentation, version
 
 ## [1.1.0] - 2022-05-17
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,18 @@ This gem includes easy system dependency manager. Run `bundle exec smtp_mock` wi
 | `session_timeout: 60` | Session timeout in seconds. It's equal to 30 seconds by default |
 | `shutdown_timeout: 5` | Graceful shutdown timeout in seconds. It's equal to 1 second by default |
 | `fail_fast: true` | Enables fail fast scenario. Disabled by default |
+| `multipleMessageReceiving: true` | Enables multiple message receiving scenario. Disabled by default |
 | `blacklisted_helo_domains: %w[a.com b.com]` | Blacklisted `HELO` domains |
 | `blacklisted_mailfrom_emails: %w[a@a.com b@b.com]` | Blacklisted `MAIL FROM` emails |
 | `blacklisted_rcptto_emails: %w[c@c.com d@d.com]` | blacklisted `RCPT TO` emails |
 | `not_registered_emails: %w[e@e.com f@f.com]` | Not registered (non-existent) `RCPT TO` emails |
+| `response_delay_helo: 2` | `HELO` response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_mailfrom: 2` | `MAIL FROM` response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_rcptto: 2` | `RCPT TO` response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_data: 2` | `DATA` response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_message: 2` | Message response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_rset: 2` | `RSET` response delay in seconds. It's equal to 0 seconds by default |
+| `response_delay_quit: 2` | `QUIT` response delay in seconds. It's equal to 0 seconds by default |
 | `msg_size_limit: 42` | Message body size limit in bytes. It's equal to 10485760 bytes by default |
 | `msg_greeting: 'Greeting message'` | Custom server greeting message |
 | `msg_invalid_cmd: 'Invalid command message'` | Custom invalid command message |
@@ -118,7 +126,9 @@ This gem includes easy system dependency manager. Run `bundle exec smtp_mock` wi
 | `msg_invalid_cmd_data_sequence: 'Invalid command DATA sequence message'` | Custom invalid command `DATA` sequence message |
 | `msg_data_received: 'DATA received message'` | Custom `DATA` received message |
 | `msg_msg_size_is_too_big: 'Message size is too big'` | Custom size is too big message |
-| `msg_msg_received: 'Message has been received'` | Custom received message body message |
+| `msg_invalid_cmd_rset_sequence: 'Invalid command RSET sequence message'` | Custom invalid command `RSET` sequence message |
+| `msg_invalid_cmd_rset_arg: 'Invalid command RSET argument message'` | Custom invalid command `RSET` argument message |
+| `msg_rset_received: 'RSET received message'` | Custom `RSET` received message |
 | `msg_quit_cmd: 'Quit command message'` | Custom quit command message |
 
 #### Example of usage

--- a/lib/smtp_mock/cli.rb
+++ b/lib/smtp_mock/cli.rb
@@ -3,7 +3,7 @@
 module SmtpMock
   module Cli
     Command = ::Struct.new(:install_path, :sudo, :success, :message) do
-      include Resolver
+      include SmtpMock::Cli::Resolver
     end
 
     def self.call(command_line_args, command = SmtpMock::Cli::Command)

--- a/lib/smtp_mock/command_line_args_builder.rb
+++ b/lib/smtp_mock/command_line_args_builder.rb
@@ -14,11 +14,18 @@ module SmtpMock
         blacklisted_rcptto_emails
         not_registered_emails
       ].freeze,
-      SmtpMock::Types::Bool.constrained(eql: true) => %i[log fail_fast].freeze,
+      SmtpMock::Types::Bool.constrained(eql: true) => %i[log fail_fast multiple_message_receiving].freeze,
       SmtpMock::Types::Integer.constrained(gteq: 1) => %i[
         port
         session_timeout
         shutdown_timeout
+        response_delay_helo
+        response_delay_mailfrom
+        response_delay_rcptto
+        response_delay_data
+        response_delay_message
+        response_delay_rset
+        response_delay_quit
         msg_size_limit
       ].freeze,
       SmtpMock::Types::String => %i[
@@ -41,6 +48,9 @@ module SmtpMock
         msg_data_received
         msg_msg_size_is_too_big
         msg_msg_received
+        msg_invalid_cmd_rset_sequence
+        msg_invalid_cmd_rset_arg
+        msg_rset_received
         msg_quit_cmd
       ].freeze
     }.freeze

--- a/lib/smtp_mock/version.rb
+++ b/lib/smtp_mock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmtpMock
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/smtp_mock/command_line_args_builder_spec.rb
+++ b/spec/smtp_mock/command_line_args_builder_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe SmtpMock::CommandLineArgsBuilder do
             msg_data_received
             msg_msg_size_is_too_big
             msg_msg_received
+            msg_invalid_cmd_rset_sequence
+            msg_invalid_cmd_rset_arg
+            msg_rset_received
             msg_quit_cmd
           ].zip('a'..'z').to_h
         end
@@ -52,6 +55,7 @@ RSpec.describe SmtpMock::CommandLineArgsBuilder do
             session_timeout: session_timeout,
             shutdown_timeout: shutdown_timeout,
             fail_fast: true,
+            multiple_message_receiving: true,
             msg_size_limit: msg_size_limit,
             blacklisted_helo_domains: blacklisted_helo_domains,
             blacklisted_mailfrom_emails: blacklisted_mailfrom_emails,
@@ -79,15 +83,19 @@ RSpec.describe SmtpMock::CommandLineArgsBuilder do
 -msgInvalidCmdMailfromSequence="g"
 -msgInvalidCmdRcpttoArg="l"
 -msgInvalidCmdRcpttoSequence="k"
+-msgInvalidCmdRsetArg="u"
+-msgInvalidCmdRsetSequence="t"
 -msgMailfromBlacklistedEmail="i"
 -msgMailfromReceived="j"
 -msgMsgReceived="s"
 -msgMsgSizeIsTooBig="r"
--msgQuitCmd="t"
+-msgQuitCmd="w"
 -msgRcpttoBlacklistedEmail="n"
 -msgRcpttoNotRegisteredEmail="m"
 -msgRcpttoReceived="o"
+-msgRsetReceived="v"
 -msgSizeLimit=#{msg_size_limit}
+-multipleMessageReceiving
 -notRegisteredEmails="#{not_registered_emails.join(',')}"
 -port=#{port}
 -sessionTimeout=#{session_timeout}


### PR DESCRIPTION
Follows new `smtpmock` feature: https://github.com/mocktools/go-smtp-mock/pull/103

- [x] Updated `SmtpMock::CommandLineArgsBuilder::PERMITTED_ATTRS`, tests
- [x] Updated rubocop/codeclimate/circleci configs
- [x] Updated gem development dependencies
- [x] Updated gem version, changelog