### PR TITLE
Feature/Ability to use multiple RCPT TO

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     - image: cimg/ruby:<< parameters.ruby-version >>
 
 orbs:
-  ruby: circleci/ruby@1.8.0
+  ruby: circleci/ruby@2.0.0
 
 references:
   restore_bundle_cache: &restore_bundle_cache
@@ -122,7 +122,7 @@ jobs:
       - checkout
       - <<: *use_compatible_gemspec
       - ruby/install-deps:
-          bundler-version: "2.3.23"
+          bundler-version: "2.3.26"
           with-cache: false
           path: './vendor/custom_bundle'
       - <<: *system_dependencies

--- a/.circleci/gemspec_compatible
+++ b/.circleci/gemspec_compatible
@@ -23,14 +23,15 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.5.0'
+  dry_struct_version = ::Gem::Version.new(::RUBY_VERSION) >= ::Gem::Version.new('2.7.0') ? '~> 1.6' : '~> 1.4'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = %w[smtp_mock]
   spec.require_paths = %w[lib]
 
-  spec.add_runtime_dependency 'dry-struct', '~> 1.4'
+  spec.add_runtime_dependency 'dry-struct', dry_struct_version
 
   spec.add_development_dependency 'ffaker', '~> 2.21'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
-  spec.add_development_dependency 'rspec', '~> 3.11'
+  spec.add_development_dependency 'rspec', '~> 3.12'
 end

--- a/.circleci/gemspec_latest
+++ b/.circleci/gemspec_latest
@@ -29,19 +29,19 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w[lib]
   spec.post_install_message = 'smtpmock is required system dependency. For more details run: `bundle exec smtp_mock -h`'
 
-  spec.add_runtime_dependency 'dry-struct', '~> 1.4'
+  spec.add_runtime_dependency 'dry-struct', '~> 1.6'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9.1'
   spec.add_development_dependency 'fasterer', '~> 0.10.0'
   spec.add_development_dependency 'ffaker', '~> 2.21'
-  spec.add_development_dependency 'net-smtp', '~> 0.3.2'
+  spec.add_development_dependency 'net-smtp', '~> 0.3.3'
   spec.add_development_dependency 'overcommit', '~> 0.59.1'
   spec.add_development_dependency 'pry-byebug', '~> 3.10', '>= 3.10.1'
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   spec.add_development_dependency 'reek', '~> 6.1', '>= 6.1.1'
-  spec.add_development_dependency 'rspec', '~> 3.11'
-  spec.add_development_dependency 'rubocop', '~> 1.36'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.15'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.13', '>= 2.13.2'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'rubocop', '~> 1.39'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.15', '>= 1.15.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.15'
   spec.add_development_dependency 'simplecov', '~> 0.21.2'
 end

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,7 +7,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-36
+    channel: rubocop-1-39
 
   reek:
     enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2022-11-19
+
+### Added
+
+- Added ability to configure multiple `RCPT TO` receiving scenario
+
+### Updated
+
+- Updated `SmtpMock::Types::Bool`, tests
+- Updated codeclimate/circleci configs
+- Updated gemspecs
+- Updated gem runtime/development dependencies
+- Updated gem documentation, version
+
 ## [1.2.2] - 2022-10-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CircleCI](https://circleci.com/gh/mocktools/ruby-smtp-mock/tree/master.svg?style=svg)](https://circleci.com/gh/mocktools/ruby-smtp-mock/tree/master)
 [![Gem Version](https://badge.fury.io/rb/smtp_mock.svg)](https://badge.fury.io/rb/smtp_mock)
 [![Downloads](https://img.shields.io/gem/dt/smtp_mock.svg?colorA=004d99&colorB=0073e6)](https://rubygems.org/gems/smtp_mock)
+[![In Awesome Ruby](https://raw.githubusercontent.com/sindresorhus/awesome/main/media/mentioned-badge.svg)](https://github.com/markets/awesome-ruby)
 [![GitHub](https://img.shields.io/github/license/mocktools/ruby-smtp-mock)](LICENSE.txt)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
@@ -95,6 +96,7 @@ This gem includes easy system dependency manager. Run `bundle exec smtp_mock` wi
 | `session_timeout: 60` | Session timeout in seconds. It's equal to 30 seconds by default |
 | `shutdown_timeout: 5` | Graceful shutdown timeout in seconds. It's equal to 1 second by default |
 | `fail_fast: true` | Enables fail fast scenario. Disabled by default |
+| `multiple_rcptto: true` | Enables multiple `RCPT TO` receiving scenario. Disabled by default |
 | `multiple_message_receiving: true` | Enables multiple message receiving scenario. Disabled by default |
 | `blacklisted_helo_domains: %w[a.com b.com]` | Blacklisted `HELO` domains |
 | `blacklisted_mailfrom_emails: %w[a@a.com b@b.com]` | Blacklisted `MAIL FROM` emails |

--- a/lib/smtp_mock/command_line_args_builder.rb
+++ b/lib/smtp_mock/command_line_args_builder.rb
@@ -14,7 +14,7 @@ module SmtpMock
         blacklisted_rcptto_emails
         not_registered_emails
       ].freeze,
-      SmtpMock::Types::Bool.constrained(eql: true) => %i[log fail_fast multiple_message_receiving].freeze,
+      SmtpMock::Types::Bool.constrained(eql: true) => %i[log fail_fast multiple_rcptto multiple_message_receiving].freeze,
       SmtpMock::Types::Integer.constrained(gteq: 1) => %i[
         port
         session_timeout

--- a/lib/smtp_mock/version.rb
+++ b/lib/smtp_mock/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmtpMock
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end

--- a/smtp_mock.gemspec
+++ b/smtp_mock.gemspec
@@ -23,16 +23,18 @@ Gem::Specification.new do |spec|
   }
 
   spec.required_ruby_version = '>= 2.5.0'
+  current_ruby_version = ::Gem::Version.new(::RUBY_VERSION)
+  dry_struct_version = current_ruby_version >= ::Gem::Version.new('2.7.0') ? '~> 1.6' : '~> 1.4'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = %w[smtp_mock]
   spec.require_paths = %w[lib]
   spec.post_install_message = 'smtpmock is required system dependency. For more details run: `bundle exec smtp_mock -h`'
 
-  spec.add_runtime_dependency 'dry-struct', '~> 1.4'
+  spec.add_runtime_dependency 'dry-struct', dry_struct_version
 
   spec.add_development_dependency 'ffaker', '~> 2.21'
-  spec.add_development_dependency 'net-smtp', '~> 0.3.2' if ::RUBY_VERSION >= '3.1.0'
+  spec.add_development_dependency 'net-smtp', '~> 0.3.3' if current_ruby_version >= ::Gem::Version.new('3.1.0')
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
-  spec.add_development_dependency 'rspec', '~> 3.11'
+  spec.add_development_dependency 'rspec', '~> 3.12'
 end

--- a/spec/smtp_mock/command_line_args_builder_spec.rb
+++ b/spec/smtp_mock/command_line_args_builder_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe SmtpMock::CommandLineArgsBuilder do
             session_timeout: session_timeout,
             shutdown_timeout: shutdown_timeout,
             fail_fast: true,
+            multiple_rcptto: true,
             multiple_message_receiving: true,
             msg_size_limit: msg_size_limit,
             blacklisted_helo_domains: blacklisted_helo_domains,
@@ -96,6 +97,7 @@ RSpec.describe SmtpMock::CommandLineArgsBuilder do
 -msgRsetReceived="v"
 -msgSizeLimit=#{msg_size_limit}
 -multipleMessageReceiving
+-multipleRcptto
 -notRegisteredEmails="#{not_registered_emails.join(',')}"
 -port=#{port}
 -sessionTimeout=#{session_timeout}


### PR DESCRIPTION
Follows new `smtpmock` feature: https://github.com/mocktools/go-smtp-mock/pull/126

- [x] Updated `SmtpMock::Types::Bool`, tests
- [x] Updated codeclimate/circleci configs
- [x] Updated gemspecs
- [x] Updated gem runtime/development dependencies
- [x] Updated gem documentation, version